### PR TITLE
Replace `dpkg` with `apt`, as this is more appropriate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Run the AppImage from the terminal:
 
 ### Debian-based systems:  
 ```bash
-sudo apt install edconv_x.x.x.deb
+sudo apt install ./edconv_x.x.x.deb
 ```
 
 ### RPM-based systems:


### PR DESCRIPTION
`apt` takes care of resolving dependencies and pulls in the required ones, it avoid leaving the package state broken.